### PR TITLE
Use env vars for IP and token

### DIFF
--- a/docs/mouse_example/mouse-example.py
+++ b/docs/mouse_example/mouse-example.py
@@ -7,10 +7,10 @@ import websockets
 
 from samsungtvws.remote import SamsungTVWS
 
-TV_IP = "192.168.0.X"
+TV_IP = os.environ.get("TV_IP", "192.168.0.X")
 
 if "X" in TV_IP:
-    raise ValueError("Please set the IP address of your TV in the TV_IP variable")
+    raise ValueError("Please set the IP address of your TV in the TV_IP variable or the TV_IP environment variable")
 
 token_file = os.path.dirname(os.path.realpath(__file__)) + "/tv-token.txt"
 tv = SamsungTVWS(host=TV_IP, port=8002, token_file=token_file)

--- a/example/art.py
+++ b/example/art.py
@@ -11,7 +11,12 @@ from samsungtvws import SamsungTVWS, exceptions, __version__
 def parseargs():
     # Add command line argument parsing
     parser = argparse.ArgumentParser(description='Example art Samsung Frame TV Version: {}'.format(__version__))
-    parser.add_argument('ip', action="store", type=str, default=None, help='ip address of TV (default: %(default)s))')
+    parser.add_argument(
+        'ip',
+        nargs='?',
+        default=os.environ.get('TV_IP'),
+        help='ip address of TV (default: env TV_IP)'
+    )
     parser.add_argument('-t','--token_file', action="store", type=str, default="token_file.txt", help='default token file to use (default: %(default)s))')
     parser.add_argument('-D','--debug', action='store_true', default=False, help='Debug mode (default: %(default)s))')
     return parser.parse_args()

--- a/example/art_remove_mats.py
+++ b/example/art_remove_mats.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 
 sys.path.append("../")
@@ -8,8 +9,10 @@ from samsungtvws import SamsungTVWS  # noqa: E402
 # Increase debug level
 logging.basicConfig(level=logging.INFO)
 
+ip = os.environ.get("TV_IP", "192.168.xxx.xxx")
+
 # Normal constructor
-tv = SamsungTVWS("192.168.xxx.xxx")
+tv = SamsungTVWS(ip)
 
 # Set all mats to this type
 target_matte_type = "none"

--- a/example/async_art.py
+++ b/example/async_art.py
@@ -12,7 +12,12 @@ from samsungtvws import exceptions, __version__
 def parseargs():
     # Add command line argument parsing
     parser = argparse.ArgumentParser(description='Example async art Samsung Frame TV Version: {}'.format(__version__))
-    parser.add_argument('ip', action="store", type=str, default=None, help='ip address of TV (default: %(default)s))')
+    parser.add_argument(
+        'ip',
+        nargs='?',
+        default=os.environ.get('TV_IP'),
+        help='ip address of TV (default: env TV_IP)'
+    )
     parser.add_argument('-t','--token_file', action="store", type=str, default="token_file.txt", help='default token file to use (default: %(default)s))')
     parser.add_argument('-D','--debug', action='store_true', default=False, help='Debug mode (default: %(default)s))')
     return parser.parse_args()

--- a/example/async_art_ensure_art_mode.py
+++ b/example/async_art_ensure_art_mode.py
@@ -6,6 +6,7 @@
 import asyncio
 import logging
 import argparse
+import os
 from pathlib import Path
 from signal import SIGTERM, SIGINT
 
@@ -114,7 +115,12 @@ class EnsureArtMode:
 def parseargs():
     # Add command line argument parsing
     parser = argparse.ArgumentParser(description='Example async ensure art mode Samsung Frame TV Version: {}'.format(__version__))
-    parser.add_argument('ip', action="store", type=str, default=None, help='ip address of TV (default: %(default)s))')
+    parser.add_argument(
+        'ip',
+        nargs='?',
+        default=os.environ.get('TV_IP'),
+        help='ip address of TV (default: env TV_IP)'
+    )
     parser.add_argument('-p','--period', action="store", type=int, default=15, help='How often to check in seconds (default: %(default)s))')
     parser.add_argument('-t','--token_file', action="store", type=str, default="token_file.txt", help='default token file to use (default: %(default)s))')
     parser.add_argument('-D','--debug', action='store_true', default=False, help='Debug mode (default: %(default)s))')

--- a/example/async_art_remove_mats.py
+++ b/example/async_art_remove_mats.py
@@ -14,7 +14,12 @@ from samsungtvws.exceptions import ResponseError
 def parseargs():
     # Add command line argument parsing
     parser = argparse.ArgumentParser(description='Async Change Mats for art on Samsung TV Version: {}'.format(__version__))
-    parser.add_argument('ip', action="store", type=str, default=None, help='ip address of TV (default: %(default)s))')
+    parser.add_argument(
+        'ip',
+        nargs='?',
+        default=os.environ.get('TV_IP'),
+        help='ip address of TV (default: env TV_IP)'
+    )
     parser.add_argument('-t','--token_file', action="store", type=str, default="token_file.txt", help='default token file to use (default: %(default)s))')
     parser.add_argument('-m','--mat', action="store", type=str, default='none', help='landscape mat to apply to art (default: %(default)s))')
     parser.add_argument('-A','--all', action='store_true', default=False, help='Apply to all art - usually just My-Photos (default: %(default)s))')

--- a/example/async_art_simple.py
+++ b/example/async_art_simple.py
@@ -12,7 +12,12 @@ from samsungtvws import exceptions, __version__
 def parseargs():
     # Add command line argument parsing
     parser = argparse.ArgumentParser(description='Example async art Samsung Frame TV Version: {}'.format(__version__))
-    parser.add_argument('ip', action="store", type=str, default=None, help='ip address of TV (default: %(default)s))')
+    parser.add_argument(
+        'ip',
+        nargs='?',
+        default=os.environ.get('TV_IP'),
+        help='ip address of TV (default: env TV_IP)'
+    )
     parser.add_argument('-t','--token_file', action="store", type=str, default="token_file.txt", help='default token file to use (default: %(default)s))')
     parser.add_argument('-D','--debug', action='store_true', default=False, help='Debug mode (default: %(default)s))')
     return parser.parse_args()

--- a/example/async_art_slideshow_anything.py
+++ b/example/async_art_slideshow_anything.py
@@ -40,7 +40,12 @@ logging.basicConfig(level=logging.INFO)
 def parseargs():
     # Add command line argument parsing
     parser = argparse.ArgumentParser(description='Async Slideshow Any art on Samsung TV Version: {}'.format(__version__))
-    parser.add_argument('ip', action="store", type=str, default=None, help='ip address of TV (default: %(default)s))')
+    parser.add_argument(
+        'ip',
+        nargs='?',
+        default=os.environ.get('TV_IP'),
+        help='ip address of TV (default: env TV_IP)'
+    )
     parser.add_argument('-f','--folder', action="store", type=str, default="./slideshow", help='folder to store images in (default: %(default)s))')
     parser.add_argument('-t','--token_file', action="store", type=str, default="token_file.txt", help='default token file to use (default: %(default)s))')
     parser.add_argument('-c','--check', action="store", type=int, default=60, help='how often to check for new art 0=run once (default: %(default)s))')

--- a/example/async_art_update_from_directory.py
+++ b/example/async_art_update_from_directory.py
@@ -75,7 +75,12 @@ logging.basicConfig(level=logging.INFO)
 def parseargs():
     # Add command line argument parsing
     parser = argparse.ArgumentParser(description='Async Upload images to Samsung TV Version: {}'.format(__version__))
-    parser.add_argument('ip', action="store", type=str, default=None, help='ip address of TV (default: %(default)s))')
+    parser.add_argument(
+        'ip',
+        nargs='?',
+        default=os.environ.get('TV_IP'),
+        help='ip address of TV (default: env TV_IP)'
+    )
     parser.add_argument('-f','--folder', action="store", type=str, default="./images", help='folder to load images from (default: %(default)s))')
     parser.add_argument('-m','--matte', action="store", type=str, default="none", help='default matte to use (default: %(default)s))')
     parser.add_argument('-t','--token_file', action="store", type=str, default="token_file.txt", help='default token file to use (default: %(default)s))')

--- a/example/async_remote.py
+++ b/example/async_remote.py
@@ -1,17 +1,31 @@
+import argparse
 import asyncio
 import logging
+import os
 
 from samsungtvws.async_remote import SamsungTVWSAsyncRemote
 from samsungtvws.remote import SendRemoteKey
 
 logging.basicConfig(level=logging.DEBUG)
 
-host = "1.2.3.4"
-port = 8002
+
+def parseargs() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ip", default=os.environ.get("TV_IP", "1.2.3.4"))
+    parser.add_argument("--port", type=int, default=8002)
+    parser.add_argument("--token", default=os.environ.get("TV_TOKEN"))
+    parser.add_argument("--token_file", default="token_file")
+    return parser.parse_args()
 
 
-async def main():
-    tv = SamsungTVWSAsyncRemote(host=host, port=port, token_file="token_file")
+async def main() -> None:
+    args = parseargs()
+    tv = SamsungTVWSAsyncRemote(
+        host=args.ip,
+        port=args.port,
+        token=args.token,
+        token_file=args.token_file,
+    )
     await tv.start_listening()
 
     # Request app_list

--- a/example/async_rest.py
+++ b/example/async_rest.py
@@ -1,6 +1,8 @@
+import argparse
 import asyncio
 import contextlib
 import logging
+import os
 
 import aiohttp
 
@@ -9,14 +11,25 @@ from samsungtvws.exceptions import HttpApiError
 
 logging.basicConfig(level=logging.DEBUG)
 
-host = "1.2.3.4"
-port = 8002
+
+def parseargs() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ip", default=os.environ.get("TV_IP", "1.2.3.4"))
+    parser.add_argument("--port", type=int, default=8002)
+    parser.add_argument("--token", default=os.environ.get("TV_TOKEN"))
+    return parser.parse_args()
 
 
-async def main():
+async def main() -> None:
+    args = parseargs()
     async with aiohttp.ClientSession() as session:
         with contextlib.suppress(HttpApiError):
-            rest_api = SamsungTVAsyncRest(host=host, port=port, session=session)
+            rest_api = SamsungTVAsyncRest(
+                host=args.ip,
+                port=args.port,
+                token=args.token,
+                session=session,
+            )
             logging.info(await rest_api.rest_device_info())
 
 

--- a/example/encrypted_authenticator.py
+++ b/example/encrypted_authenticator.py
@@ -1,5 +1,7 @@
 import asyncio
+import argparse
 import logging
+import os
 from typing import Optional
 
 import aiohttp
@@ -8,8 +10,12 @@ from samsungtvws.encrypted.authenticator import SamsungTVEncryptedWSAsyncAuthent
 
 logging.basicConfig(level=logging.DEBUG)
 
-HOST = "1.2.3.4"
-PORT = 8080  # Warning: this can be different from the remote port
+
+def parseargs() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ip", default=os.environ.get("TV_IP", "1.2.3.4"))
+    parser.add_argument("--port", type=int, default=8080)
+    return parser.parse_args()
 
 
 async def _get_token(
@@ -31,8 +37,9 @@ async def _get_token(
 
 async def main() -> None:
     """Get token."""
+    args = parseargs()
     async with aiohttp.ClientSession() as web_session:
-        token, session_id = await _get_token(HOST, web_session, PORT)
+        token, session_id = await _get_token(args.ip, web_session, args.port)
         print(f"Token: '{token}', session: '{session_id}'")
 
 

--- a/example/encrypted_remote.py
+++ b/example/encrypted_remote.py
@@ -1,5 +1,7 @@
+import argparse
 import asyncio
 import logging
+import os
 
 import aiohttp
 
@@ -7,22 +9,26 @@ from samsungtvws.encrypted.remote import SamsungTVEncryptedWSAsyncRemote, SendRe
 
 logging.basicConfig(level=logging.DEBUG)
 
-HOST = "1.2.3.4"
-PORT = 8000  # Warning: this can be different from the authenticator port
 
-TOKEN = "b231074ae524245f4dd581154c112936"
-SESSION_ID = "1"
+def parseargs() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ip", default=os.environ.get("TV_IP", "1.2.3.4"))
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--token", default=os.environ.get("TV_TOKEN"))
+    parser.add_argument("--session_id", default="1")
+    return parser.parse_args()
 
 
 async def main() -> None:
-    """Get token."""
+    """Run remote commands."""
+    args = parseargs()
     async with aiohttp.ClientSession() as web_session:
         remote = SamsungTVEncryptedWSAsyncRemote(
-            host=HOST,
+            host=args.ip,
             web_session=web_session,
-            token=TOKEN,
-            session_id=SESSION_ID,
-            port=PORT,
+            token=args.token,
+            session_id=args.session_id,
+            port=args.port,
         )
         await remote.start_listening()
 

--- a/example/example.py
+++ b/example/example.py
@@ -12,11 +12,12 @@ from samsungtvws import SamsungTVWS  # noqa: E402
 logging.basicConfig(level=logging.INFO)
 
 # Normal constructor
-tv = SamsungTVWS("192.168.xxx.xxx")
+ip = os.environ.get("TV_IP", "192.168.xxx.xxx")
+tv = SamsungTVWS(ip)
 
 # Autosave token to file
 token_file = os.path.dirname(os.path.realpath(__file__)) + "/tv-token.txt"
-tv = SamsungTVWS(host="192.168.xxx.xxx", port=8002, token_file=token_file)
+tv = SamsungTVWS(host=ip, port=8002, token_file=token_file)
 
 # Toggle power
 tv.shortcuts().power()

--- a/example/manual_slideshow.py
+++ b/example/manual_slideshow.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 import argparse
 import logging
+import os
 
 from samsungtvws import SamsungTVWS, exceptions, __version__
 
 def parseargs():
     # Add command line argument parsing
     parser = argparse.ArgumentParser(description='Example art Samsung Frame TV Version: {}'.format(__version__))
-    parser.add_argument('ip', action="store", type=str, default=None, help='ip address of TV (default: %(default)s))')
+    parser.add_argument(
+        'ip',
+        nargs='?',
+        default=os.environ.get('TV_IP'),
+        help='ip address of TV (default: env TV_IP)'
+    )
     parser.add_argument('-t','--token_file', action="store", type=str, default="token_file.txt", help='default token file to use (default: %(default)s))')
     parser.add_argument('-D','--debug', action='store_true', default=False, help='Debug mode (default: %(default)s))')
     return parser.parse_args()

--- a/example/web_interface/web_interface.py
+++ b/example/web_interface/web_interface.py
@@ -30,7 +30,12 @@ logging.basicConfig(level=logging.INFO)
 def parseargs():
     # Add command line argument parsing
     parser = argparse.ArgumentParser(description='Async Art gallery for Samsung Frame TV Version: {}'.format(__version__))
-    parser.add_argument('ip', action="store", type=str, default=None, help='ip address of TV (default: %(default)s))')
+    parser.add_argument(
+        'ip',
+        nargs='?',
+        default=os.environ.get('TV_IP'),
+        help='ip address of TV (default: env TV_IP)'
+    )
     parser.add_argument('-p','--port', action="store", type=int, default=5000, help='port for web page interface (default: %(default)s))')
     parser.add_argument('-f','--folder', action="store", type=str, default="./images", help='folder to load images from (default: %(default)s))')
     parser.add_argument('-m','--matte', action="store", type=str, default="none", help='default matte to use (default: %(default)s))')


### PR DESCRIPTION
## Summary
- load TV IP and token from `TV_IP` and `TV_TOKEN` env vars
- allow overriding with CLI flags in example scripts

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: coroutine raised StopIteration)*

------
https://chatgpt.com/codex/tasks/task_e_68630ecf27f48326addbd88d206d2642