### PR TITLE
Add production TV control scripts

### DIFF
--- a/scripts/turn_artmode_on.py
+++ b/scripts/turn_artmode_on.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import logging
+import os
+
+from dotenv import load_dotenv
+from samsungtvws import SamsungTVWS, exceptions
+
+
+def main() -> None:
+    load_dotenv()
+    logging.basicConfig(level=logging.INFO)
+
+    ip = os.getenv("TV_IP")
+    token = os.getenv("TV_TOKEN")
+    if not ip or not token:
+        logging.error("Environment variables TV_IP and TV_TOKEN must be set")
+        return
+
+    tv = SamsungTVWS(host=ip, port=8002, token=token)
+    try:
+        tv.art().set_artmode("on")
+        logging.info("Art Mode enabled")
+    except exceptions.ConnectionFailure as err:
+        logging.error("Failed to connect to TV: %s", err)
+    except Exception as err:  # noqa: BLE001
+        logging.error("Failed to enable Art Mode: %s", err)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/turn_power_off.py
+++ b/scripts/turn_power_off.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import logging
+import os
+
+from dotenv import load_dotenv
+from samsungtvws import SamsungTVWS, exceptions
+
+
+def main() -> None:
+    load_dotenv()
+    logging.basicConfig(level=logging.INFO)
+
+    ip = os.getenv("TV_IP")
+    token = os.getenv("TV_TOKEN")
+    if not ip or not token:
+        logging.error("Environment variables TV_IP and TV_TOKEN must be set")
+        return
+
+    tv = SamsungTVWS(host=ip, port=8002, token=token)
+    try:
+        tv.send_key("KEY_POWEROFF")
+        logging.info("Power off command sent")
+    except exceptions.ConnectionFailure as err:
+        logging.error("Failed to connect to TV: %s", err)
+    except Exception as err:  # noqa: BLE001
+        logging.error("Failed to send power off command: %s", err)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/turn_power_on.py
+++ b/scripts/turn_power_on.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import logging
+import os
+
+from dotenv import load_dotenv
+from samsungtvws import SamsungTVWS, exceptions
+
+
+def main() -> None:
+    load_dotenv()
+    logging.basicConfig(level=logging.INFO)
+
+    ip = os.getenv("TV_IP")
+    token = os.getenv("TV_TOKEN")
+    if not ip or not token:
+        logging.error("Environment variables TV_IP and TV_TOKEN must be set")
+        return
+
+    tv = SamsungTVWS(host=ip, port=8002, token=token)
+    try:
+        tv.send_key("KEY_POWER")
+        logging.info("Power on command sent")
+    except exceptions.ConnectionFailure as err:
+        logging.error("Failed to connect to TV: %s", err)
+    except Exception as err:  # noqa: BLE001
+        logging.error("Failed to send power on command: %s", err)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide minimal `scripts/` folder
- add scripts to turn power on, power off, and enable art mode using env vars

## Testing
- `pre-commit run --files scripts/turn_power_on.py scripts/turn_power_off.py scripts/turn_artmode_on.py` *(fails: CalledProcessError due to SSL certificate verify failed when installing node)*
- `pytest -q` *(fails: 15 failed, 11 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68631122c23083268a6bc6e367b6a659